### PR TITLE
Doppelte Doppelstarterkontrolle mit Berücksichtingung Kategorie und Kontrolle Startnummer

### DIFF
--- a/sasse/queries.py
+++ b/sasse/queries.py
@@ -563,7 +563,7 @@ def _mark_double_trouble(sorted_ds):
         if previous_row and previous_row['doppel'] and row['doppel']:
             previous_item = previous_row['doppel'][0]
             item = row['doppel'][0]
-            if item['startnummer'] == previous_item['startnummer']:
+            if item['startnummer'] == previous_item['startnummer'] and item['disziplin'] == previous_item['disziplin']:
                 previous_row['trouble'] = True
                 row['trouble'] = True
         previous_row = row

--- a/sasse/queries.py
+++ b/sasse/queries.py
@@ -456,6 +456,7 @@ def read_doppelstarter(wettkampf, disziplinart):
     grouped_ds = _group_doppelstarter(ds)
     sorted_ds = sorted(grouped_ds, key=_sort_doppelstarter_nummer)
     _mark_double_trouble(sorted_ds)
+    _mark_double_start_before(sorted_ds)
     return sorted_ds
 
 def _read_doppelstarter(wettkampf, disziplinart):
@@ -541,6 +542,10 @@ def _group_doppelstarter(doppelstarter):
         row['normal'] = normal
         if len(normal) != 1 or len(doppel) != 1:
             row['trouble'] = True
+            if len(normal) > 1:
+                row['troubleTxt'] = "Nicht als Doppelstarter markiert"
+            else:
+                row['troubleTxt'] = "Mehrfach als Doppelstarter markiert"
         result.append(row)
     return result
 
@@ -566,7 +571,18 @@ def _mark_double_trouble(sorted_ds):
             if item['startnummer'] == previous_item['startnummer'] and item['disziplin'] == previous_item['disziplin']:
                 previous_row['trouble'] = True
                 row['trouble'] = True
+                row['troubleTxt'] = "Mehr als ein Doppelstarter mit selber Startnr"
+                previous_row['troubleTxt'] = row['troubleTxt']
         previous_row = row
+
+def _mark_double_start_before(sorted_ds):
+    """
+    Doppelstarterstartnummer sollte immer grösser als Startnummer ohne Doppelstarter sein.
+    """
+    for row in sorted_ds:
+        if len(row['doppel']) > 0 and len(row['normal']) > 0 and row['normal'][0]['startnummer'] >= row['doppel'][0]['startnummer']:
+            row['trouble'] = True
+            row['troubleTxt'] = "Doppelstarter Startnr ist kleiner als normale Startnr"
 
 def read_sektionsfahren_gruppen_counts(disziplin, gruppe=None):
     cursor = connection.cursor()

--- a/sasse/templates/doppelstarter_einzelfahren.html
+++ b/sasse/templates/doppelstarter_einzelfahren.html
@@ -2,16 +2,16 @@
 {% block nav_wettkampf %}selected{% endblock %}
 {% block content %}
 <style>
-    table.list tr.trouble {
+  table.list tr.trouble {
     background-color: red;
-    }
+  }
 </style>
 <p>
-<strong>Doppelstarter Einzelfahren.</strong>
-Anzeige der Mitglieder, die in mehr als einem Schiff gestartet sind und/oder
-als Doppelstarter bei der Eingabe der Startliste markiert wurden. Problemfälle
-werden rot hinterlegt (z.B. mehr als einmal gestartet aber nicht als
-Doppelstarter markiert).
+  <strong>Doppelstarter Einzelfahren.</strong>
+  Anzeige der Mitglieder, die in mehr als einem Schiff gestartet sind und/oder
+  als Doppelstarter bei der Eingabe der Startliste markiert wurden. Problemfälle
+  werden rot hinterlegt (z.B. mehr als einmal gestartet aber nicht als
+  Doppelstarter markiert).
 </p>
 <table class="list">
   <tr>
@@ -19,22 +19,26 @@ Doppelstarter markiert).
     <th>Normal</th>
     <th>Name</th>
     <th>Sektion</th>
+    <th>Problem</th>
   </tr>
   {% for row in doppelstarter %}
-  <tr class="{{row.trouble|yesno:"trouble,"}}">
+  <tr class="{{row.trouble|yesno:" trouble,"}}">
     <td>
-    {% for item in row.doppel %}
-    <a href="{% url 'teilnehmer_get' wettkampf.jahr wettkampf.name item.disziplin item.startnummer %}">{{item.startnummer}}</a>
-    {% endfor %}
+      {% for item in row.doppel %}
+      <a
+        href="{% url 'teilnehmer_get' wettkampf.jahr wettkampf.name item.disziplin item.startnummer %}">{{item.startnummer}}</a>
+      {% endfor %}
     </td>
     <td>
-    {% for item in row.normal %}
-    <a href="{% url 'teilnehmer_get' wettkampf.jahr wettkampf.name item.disziplin item.startnummer %}">{{item.startnummer}}</a>
-    {% endfor %}
+      {% for item in row.normal %}
+      <a
+        href="{% url 'teilnehmer_get' wettkampf.jahr wettkampf.name item.disziplin item.startnummer %}">{{item.startnummer}}</a>
+      {% endfor %}
     </td>
     <td>{{row.name}} {{row.vorname}}</td>
     <td>{{row.sektion}}</td>
+    <td>{{row.troubleTxt}}</td>
   </tr>
-{% endfor %}
+  {% endfor %}
 </table>
 {% endblock %}


### PR DESCRIPTION
Nach Wynau 2026: für Markierung doppelte Doppelstarter wird die Kategorie berücksichtigt. Es können die selben Startnummern in Kat. I und II-FII-III-FIII-C-D-F vorhanden sein.